### PR TITLE
chore: remove unused imports in UPDATE_ISSUE_STATUS_MUTATION.ts

### DIFF
--- a/src/gql/UPDATE_ISSUE_STATUS_MUTATION.test.ts
+++ b/src/gql/UPDATE_ISSUE_STATUS_MUTATION.test.ts
@@ -1,0 +1,11 @@
+import { UPDATE_ISSUE_STATUS_MUTATION } from "./UPDATE_ISSUE_STATUS_MUTATION";
+
+describe("UPDATE_ISSUE_STATUS_MUTATION", () => {
+  it("should be a defined object", () => {
+    expect(UPDATE_ISSUE_STATUS_MUTATION).toBeDefined();
+  });
+
+  it("should have the correct kind", () => {
+    expect(UPDATE_ISSUE_STATUS_MUTATION.kind).toBe("Document");
+  });
+});

--- a/src/gql/UPDATE_ISSUE_STATUS_MUTATION.ts
+++ b/src/gql/UPDATE_ISSUE_STATUS_MUTATION.ts
@@ -1,7 +1,4 @@
-// import { gql } from "urql";
 import { gql } from "graphql-tag";
-// TODO: remove and test
-// import { IssueStatus } from "@/db/schema";
 
 export const UPDATE_ISSUE_STATUS_MUTATION = gql`
   mutation UpdateIssueStatus($id: String!, $status: IssueStatus!) {


### PR DESCRIPTION
Removed commented-out `urql` import and `IssueStatus` import/TODO from `src/gql/UPDATE_ISSUE_STATUS_MUTATION.ts`. Added a unit test `src/gql/UPDATE_ISSUE_STATUS_MUTATION.test.ts` to verify the mutation export validity. Verified changes with existing and new tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the mutation module and adds a sanity test for its export.
> 
> - Removes commented `urql` and `IssueStatus` imports/TODO from `UPDATE_ISSUE_STATUS_MUTATION.ts`; retains `gql` from `graphql-tag`
> - Adds `UPDATE_ISSUE_STATUS_MUTATION.test.ts` to assert the export is defined and has `kind: "Document"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f449c632601f9c47ca0e01ec1e8662e3f970731d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->