### PR TITLE
🧹 make theme value passable in UserProvider

### DIFF
--- a/src/app/context/UserContext.test.tsx
+++ b/src/app/context/UserContext.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { UserProvider, useUserContext } from "./UserContext";
+import "@testing-library/jest-dom";
+
+const TestComponent = () => {
+  const { theme } = useUserContext();
+  return <div data-testid="theme-value">{theme}</div>;
+};
+
+describe("UserProvider", () => {
+  test("defaults to light theme when no initialTheme is provided", () => {
+    render(
+      <UserProvider>
+        <TestComponent />
+      </UserProvider>
+    );
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("light");
+  });
+
+  test("uses provided initialTheme", () => {
+    render(
+      <UserProvider initialTheme="dark">
+        <TestComponent />
+      </UserProvider>
+    );
+    expect(screen.getByTestId("theme-value")).toHaveTextContent("dark");
+  });
+});

--- a/src/app/context/UserContext.tsx
+++ b/src/app/context/UserContext.tsx
@@ -9,11 +9,15 @@ import { Theme, User, UserContextProps } from "./UserContextType";
 
 type UserProviderType = {
   children: ReactNode;
+  initialTheme?: Theme;
 };
 const UserContext = createContext<UserContextProps | undefined>(undefined);
-// TODO: make theme value passable than default to light
-export const UserProvider = ({ children }: UserProviderType) => {
-  const [theme, setTheme] = useState<Theme>("light");
+
+export const UserProvider = ({
+  children,
+  initialTheme = "light",
+}: UserProviderType) => {
+  const [theme, setTheme] = useState<Theme>(initialTheme);
   const [user, setUser] = useState<User | null>(null);
 
   const toggleTheme = () => {


### PR DESCRIPTION
🎯 **What:** The `UserProvider` in `src/app/context/UserContext.tsx` was using a hardcoded default value of `"light"` for the theme state. I've updated it to accept an optional `initialTheme` prop.

💡 **Why:** This refactoring allows the theme to be initialized with a specific value via props, which makes the context more flexible and easier to test without changing its behavior for existing consumers.

✅ **Verification:**
- Manually verified the code changes for correctness and backward compatibility.
- Added a new test file `src/app/context/UserContext.test.tsx` that covers default and custom initial values.
- Received positive code review.

✨ **Result:** `UserProvider` now supports an optional `initialTheme` prop, improving its flexibility and aligning with React context best practices.

---
*PR created automatically by Jules for task [9908055973630515177](https://jules.google.com/task/9908055973630515177) started by @parvezk*