### PR TITLE
⚡ [performance improvement] Lazy Load GraphQL User Context

### DIFF
--- a/src/app/api/graphql/resolvers.ts
+++ b/src/app/api/graphql/resolvers.ts
@@ -12,7 +12,8 @@ import { GQLContext } from "@/types/GQLContext";
 const resolvers = {
   Query: {
     issues: async (_parent, _args, context: GQLContext) => {
-      if (!context.user)
+      const user = await context.getUser();
+      if (!user)
         throw new GraphQLError("ISSUES UNAUTHORIZED", {
           extensions: { code: 401 },
         });
@@ -21,7 +22,7 @@ const resolvers = {
         return await db
           .select()
           .from(issues)
-          .where(eq(issues.userId, context.user.id))
+          .where(eq(issues.userId, user.id as string))
           .orderBy(desc(issues.createdAt));
       } catch (err) {
         console.error("Failed to fetch issues:", err);
@@ -32,13 +33,14 @@ const resolvers = {
     },
 
     user: async (_parent, _args, context: GQLContext) => {
-      if (!context.user)
+      const currentUser = await context.getUser();
+      if (!currentUser)
         throw new GraphQLError("UNAUTHORIZED", {
           extensions: { code: 401 },
         });
 
       const user = await db.query.users.findFirst({
-        where: eq(users.id, context.user.id),
+        where: eq(users.id, currentUser.id as string),
       });
 
       if (!user)
@@ -52,12 +54,13 @@ const resolvers = {
 
   Mutation: {
     createIssue: async (_parent, { input }, context: GQLContext) => {
-      if (!context.user)
+      const user = await context.getUser();
+      if (!user)
         throw new GraphQLError("UNAUTHORIZED", { extensions: { code: 401 } });
 
       const issueData = {
         ...input,
-        userId: context.user.id,
+        userId: user.id as string,
         status: input.status || IssueStatus.BACKLOG,
       };
 
@@ -71,7 +74,8 @@ const resolvers = {
     },
 
     updateIssueStatus: async (_parent, { id, status }, context: GQLContext) => {
-      if (!context.user)
+      const user = await context.getUser();
+      if (!user)
         throw new GraphQLError("UNAUTHORIZED", { extensions: { code: 401 } });
       const [updatedIssue] = await db
         .update(issues)
@@ -87,7 +91,8 @@ const resolvers = {
     },
 
     deleteIssue: async (_parent, { id }, context: GQLContext) => {
-      if (!context.user)
+      const user = await context.getUser();
+      if (!user)
         throw new GraphQLError("UNAUTHORIZED", { extensions: { code: 401 } });
 
       const [deletedIssue] = await db

--- a/src/app/api/graphql/route.ts
+++ b/src/app/api/graphql/route.ts
@@ -21,19 +21,24 @@ export async function POST(req: NextRequest) {
   try {
     const { query, variables } = await req.json();
 
-    const context = async (req: NextRequest) => {
-      const user = await getUserFromToken(
-        req.headers.get("authorization") ?? ""
-      );
+    const context = (req: NextRequest) => {
+      let userPromise: Promise<any> | null = null;
 
-      return { req, user };
+      const getUser = () => {
+        if (!userPromise) {
+          userPromise = getUserFromToken(req.headers.get("authorization") ?? "");
+        }
+        return userPromise;
+      };
+
+      return { req, getUser };
     };
 
     const response = await graphql({
       schema,
       source: query,
       variableValues: variables,
-      contextValue: await context(req),
+      contextValue: context(req),
     });
 
     const headers = new Headers(header);

--- a/src/types/GQLContext.ts
+++ b/src/types/GQLContext.ts
@@ -1,3 +1,6 @@
+import { NextRequest } from "next/server";
+
 export type GQLContext = {
-  user?: { id?: string; email: string; createdAt?: string } | null;
+  req: NextRequest;
+  getUser: () => Promise<{ id?: string; email: string; createdAt?: string } | null>;
 };


### PR DESCRIPTION
💡 **What:** 
The optimization changes the GraphQL endpoint to lazily fetch the authenticated user. Instead of awaiting `getUserFromToken` upfront on every POST request for GraphQL, a `getUser()` async function is injected into the GraphQL context which fetches the token when invoked and memoizes the result. Resolvers have been updated to `await context.getUser()` rather than expecting the user object directly.

🎯 **Why:** 
The GraphQL context generation logic hits the database `users` table via `getUserFromToken` to authenticate requests. Executing this eagerly meant hitting the database on every query—even introspection queries and operations that do not require authentication (e.g., login, signup). Implementing a lazy getter completely eliminates database access on public operations and keeps memory and processing down until it is strictly needed by a resolver.

📊 **Measured Improvement:** 
Before this change, every GraphQL query hit the SQLite/Turso database to resolve authentication context upfront. After the change, queries that don't need authentication avoid the database altogether. Since we skipped setting up a formal benchmark per user preference, the performance win mathematically relates directly to network I/O: 1 omitted roundtrip DB query for public API paths like Introspection or unauthenticated calls.

✅ **Verification:** 
- The project's linters (`npm run lint`), typescript compilation (`npm run build`), and tests (`npm test`) execute correctly and show 100% pass rates across test suites. 
- All resolvers cleanly implement `const user = await context.getUser()`.

---
*PR created automatically by Jules for task [5286669513808217383](https://jules.google.com/task/5286669513808217383) started by @parvezk*