### PR TITLE
🧹 [code health improvement] Remove eslint disable comment and unused variable in auth.ts

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -51,8 +51,7 @@ export const signin = async ({
   if (!correctPW) return null;
 
   const token = createTokenForUser(match);
-  // eslint-disable-next-line unused-imports/no-unused-vars
-  const { password: _, ...user } = match;
+  const { password, ...user } = match;
 
   return { user, token };
 };


### PR DESCRIPTION
🎯 What
Removed the `// eslint-disable-next-line unused-imports/no-unused-vars` comment and simplified the object destructuring in `src/utils/auth.ts` from `const { password: _, ...user } = match;` to `const { password, ...user } = match;`.

💡 Why
The destructuring was explicitly aliasing `password` to an unused variable `_` and ignoring it with an ESLint comment. By directly destructuring `password` alongside the rest `...user` parameters, we achieve the exact same functional result (omitting `password` from `user`) while naturally bypassing unused variable warnings, improving code readability and cleanliness.

✅ Verification
Ran the `npm run lint` and `npm run test` commands. The linting process passed without errors, demonstrating that the ESLint disable comment is no longer needed. The test suite execution passed completely as well, confirming that auth functionality remains intact.

✨ Result
A cleaner, more readable `src/utils/auth.ts` file without unnecessary linter suppression comments.

---
*PR created automatically by Jules for task [13555085638189015141](https://jules.google.com/task/13555085638189015141) started by @parvezk*