### PR TITLE
🔒 [security fix] Restrict Apollo Studio CORS origin to non-production environments

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,8 +5,11 @@ export function middleware(req: NextRequest) {
   const allowedOriginsStr = process.env.ALLOWED_ORIGINS || "";
   const allowedOrigins = allowedOriginsStr.split(",").map(origin => origin.trim()).filter(Boolean);
 
-  // Always allow Apollo Studio for GraphQL exploration
-  if (!allowedOrigins.includes("https://studio.apollographql.com")) {
+  // Allow Apollo Studio for GraphQL exploration in non-production environments
+  if (
+    process.env.NODE_ENV !== "production" &&
+    !allowedOrigins.includes("https://studio.apollographql.com")
+  ) {
     allowedOrigins.push("https://studio.apollographql.com");
   }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a hardcoded allowance of `https://studio.apollographql.com` as a CORS origin in all environments.

⚠️ **Risk:** Allowing the Apollo Studio origin in production could potentially allow unauthorized GraphQL exploration and interaction if the endpoint is exposed.

🛡️ **Solution:** The fix restricts the automatic inclusion of the Apollo Studio origin to non-production environments by checking `process.env.NODE_ENV !== "production"`. It still allows explicit configuration via the `ALLOWED_ORIGINS` environment variable.

---
*PR created automatically by Jules for task [6137160489063293217](https://jules.google.com/task/6137160489063293217) started by @parvezk*